### PR TITLE
xfm: Move to xen-sys::xenforeignmemory_mmap() interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "xen-ioctls"
 version = "0.0.0-pre1"
-source = "git+https://gitlab.com/mathieupoirier/oxerun/?branch=xen-ioctls#e7a5893e0e8e51f4d4f9567b19136f56d560e7d4"
+source = "git+https://gitlab.com/mathieupoirier/oxerun/?branch=xen-ioctls#37364288517096f09e3f513d4131fd2020d91df9"
 dependencies = [
  "libc",
 ]

--- a/src/xfm.rs
+++ b/src/xfm.rs
@@ -10,9 +10,8 @@ use std::slice;
 
 use super::{Error, Result};
 use libxen_sys::{
-    domid_t, ioreq, ioservid_t, shared_iopage, xen_pfn_t, xenforeignmemory_close,
-    xenforeignmemory_handle, xenforeignmemory_open, xentoollog_logger,
-    XENMEM_resource_ioreq_server, XC_PAGE_SHIFT,
+    domid_t, ioreq, ioservid_t, shared_iopage, xen_pfn_t, XENMEM_resource_ioreq_server,
+    XC_PAGE_SHIFT,
 };
 use xen_ioctls::{
     xenforeignmemory_map, xenforeignmemory_map_resource, xenforeignmemory_unmap,
@@ -20,7 +19,6 @@ use xen_ioctls::{
 };
 
 pub struct XenForeignMemory {
-    xfh: *mut xenforeignmemory_handle,
     res: Option<XenForeignMemoryResourceHandle>,
     ioreq: *mut ioreq,
     addr: Vec<(*mut c_void, u64)>,
@@ -28,14 +26,7 @@ pub struct XenForeignMemory {
 
 impl XenForeignMemory {
     pub fn new() -> Result<Self> {
-        let xfh = unsafe { xenforeignmemory_open(ptr::null_mut::<xentoollog_logger>(), 0) };
-
-        if xfh.is_null() {
-            return Err(Error::XenForeignMemoryFailure);
-        }
-
         Ok(Self {
-            xfh,
             res: None,
             ioreq: ptr::null_mut::<ioreq>(),
             addr: Vec::new(),
@@ -127,9 +118,5 @@ impl Drop for XenForeignMemory {
     fn drop(&mut self) {
         self.unmap_mem().unwrap();
         self.unmap_resource().unwrap();
-
-        unsafe {
-            xenforeignmemory_close(self.xfh);
-        }
     }
 }


### PR DESCRIPTION
Hi Viresh,

This pull request uses the xen-sys xenforeighmemory mmap() API instead of the one found in libxen.  I tested things on my side and everything looks good - please see if you can find the same results on your side.

In a previous email conversation we talked about returning a MmapRegionBuilder, but that was left out in this version.  We can talk about the requirements for that in Cambridge.

Thanks,
Mathieu